### PR TITLE
Use unsafe pointers in raw allocator to fix potential alignment problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 example/main
 coverage.out
+profile.out
 make
 bin/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ go run make itself
 ```
 
 Roadmap
+1. get rid of reflect in library code by replacing reflect.SliceHeader with private type
 1. arena map on top of linear hashing alg
 1. instrumented arena
 1. create additional methods for allocation within limits that can accept to sizes (minSize, preferableSize)

--- a/cmd/internal/make.go
+++ b/cmd/internal/make.go
@@ -46,6 +46,7 @@ var commands = []Command{
 	{`profileRawAlloc`, profileAllocBench(`BenchmarkRawAllocator`)},
 	{`profileManagedRawAlloc`, profileAllocBench(`BenchmarkManagedRawAllocator`)},
 	{`profileDynamicAlloc`, profileAllocBench(`BenchmarkDynamicAllocator`)},
+	{`profileManagedDynWithPreAlloc`, profileAllocBench(`BenchmarkManagedDynamicAllocatorWithPreAlloc`)},
 	{`profileGenericAlloc`, profileAllocBench(`BenchmarkGenericAllocatorWithSubClean`)},
 
 	{`benchAlloc`, b.RunCmd(

--- a/cmd/internal/make.go
+++ b/cmd/internal/make.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/storozhukBM/downloader"
 )
 
-const golangCiLinterVersion = `1.24.0`
+const golangCiLinterVersion = `1.30.0`
 
 const profileName = `profile.out`
 const coverageName = `coverage.out`
@@ -199,21 +199,32 @@ func main() {
 }
 
 const golangcilintChecksumFile = `
-aeaa5498682246b87d0b77ece283897348ea03d98e816760a074058bfca60b2a  golangci-lint-1.24.0-windows-amd64.zip
-7e854a70d449fe77b7a91583ec88c8603eb3bf96c45d52797dc4ba3f2f278dbe  golangci-lint-1.24.0-darwin-386.tar.gz
-835101fae192c3a2e7a51cb19d5ac3e1a40b0e311955e89bc21d61de78635979  golangci-lint-1.24.0-linux-armv6.tar.gz
-a041a6e6a61c9ff3dbe58673af13ea00c76bcd462abede0ade645808e97cdd6d  golangci-lint-1.24.0-windows-386.zip
-7cc73eb9ca02b7a766c72b913f8080401862b10e7bb90c09b085415a81f21609  golangci-lint-1.24.0-freebsd-armv6.tar.gz
-537bb2186987b5e68ad4e8829230557f26087c3028eb736dea1662a851bad73d  golangci-lint-1.24.0-linux-armv7.tar.gz
-8cb1bc1e63d8f0d9b71fcb10b38887e1646a6b8a120ded2e0cd7c3284528f633  golangci-lint-1.24.0-linux-mips64.tar.gz
-095d3f8bf7fc431739861574d0b58d411a617df2ed5698ce5ae5ecc66d23d44d  golangci-lint-1.24.0-freebsd-armv7.tar.gz
-e245df27cec3827aef9e7afbac59e92816978ee3b64f84f7b88562ff4b2ac225  golangci-lint-1.24.0-linux-arm64.tar.gz
-35d6d5927e19f0577cf527f0e4441dbb37701d87e8cf729c98a510fce397fbf7  golangci-lint-1.24.0-linux-ppc64le.tar.gz
-a1ed66353b8ceb575d78db3051491bce3ac1560e469a9bc87e8554486fec7dfe  golangci-lint-1.24.0-freebsd-386.tar.gz
-241ca454102e909de04957ff8a5754c757cefa255758b3e1fba8a4533d19d179  golangci-lint-1.24.0-linux-amd64.tar.gz
-ff488423db01a0ec8ffbe4e1d65ef1be6a8d5e6d7930cf380ce8aaf714125470  golangci-lint-1.24.0-linux-386.tar.gz
-f05af56f15ebbcf77663a8955d1e39009b584ce8ea4c5583669369d80353a113  golangci-lint-1.24.0-darwin-amd64.tar.gz
-b0096796c0ffcd6c350a2ec006100e7ef5f0597b43a204349d4f997273fb32a7  golangci-lint-1.24.0-freebsd-amd64.tar.gz
-c9c2867380e85628813f1f7d1c3cfc6c6f7931e89bea86f567ff451b8cdb6654  golangci-lint-1.24.0-linux-mips64le.tar.gz
-2feb97fa61c934aa3eba9bc104ab5dd8fb946791d58e64060e8857e800eeae0b  golangci-lint-1.24.0-linux-s390x.tar.gz
+0701ede88347aa0ad7bd5c2bcc22d7d7b64ae7e9828abd3c4fe5a8c57c4f7b5a  golangci-lint-1.30.0-linux-s390x.rpm
+191f21f971054b6a016027c73f7643402a9b3322fe42be3cc1533605a67de21a  golangci-lint-1.30.0-linux-amd64.deb
+258e51decfe286e2f3b985ef2eece6197dc61f1e50bc1ca4986d23776a673737  golangci-lint-1.30.0-darwin-amd64.tar.gz
+2dd52d77d9dc0aff73a85938a12e53f4a3688cf19e9ca52632629771a5fd664c  golangci-lint-1.30.0-linux-386.rpm
+2f0c6c747f03bf75594bc34969d9f5e919a9becea7d5fa23599f63150a960c2c  golangci-lint-1.30.0-windows-amd64.zip
+320156934ee15977b03da44f2fed88d3f6ad3480d08adea3fe9e999cc026c248  golangci-lint-1.30.0-linux-arm64.deb
+34bf2ce67182b9f74c69ed1768c327ff140dd6029e46498c12bd88a25dd809a2  golangci-lint-1.30.0-freebsd-armv7.tar.gz
+484e0ab3644068585528f0c0d35c6fe97451eade659cb12ff5f14c1d4c5f36ba  golangci-lint-1.30.0-linux-amd64.rpm
+4db9f2ee472d02167e26dc4a4afb8880b58fc8b409c713314d89d5f24b76d8be  golangci-lint-1.30.0-windows-386.zip
+5ab313c203522b8ef0fca4a86f03c21647552eb126682f6bb6e0c2c27519806a  golangci-lint-1.30.0-linux-s390x.tar.gz
+5c91512b4120620513b3e551e996ec2d0d476d0feb503c6e932c8336949cdc74  golangci-lint-1.30.0-linux-ppc64le.rpm
+63e43bddd08485e3c652d399d11486874427fd4cdd4ef26d3b96168d63e1450c  golangci-lint-1.30.0-linux-armv7.deb
+669ef3611963b44dc5b6cbf3709b5dd56c9d1dab11562309a5cdefcf4096eed0  golangci-lint-1.30.0-linux-armv6.tar.gz
+74fbcf4110ec10b0ddcc1779cfbe11a83ce1b7b83920d8eefa195cc93e3c11f3  golangci-lint-1.30.0-linux-386.tar.gz
+9556cba775505e270b1e6c9549fe6673bf3c36f1bda3aefe2e253749f2f9cecb  golangci-lint-1.30.0-linux-386.deb
+a9c1d14d84a687fb8e67c2c613533ec3e2802b5baf95ca82ad528f788cb6d61f  golangci-lint-1.30.0-linux-arm64.tar.gz
+b0cb8001137e1a3e465204b9176e136c29399e94f4b494020471b2e8559a28b6  golangci-lint-1.30.0-linux-ppc64le.tar.gz
+b542d5cabe71649a8ae57dbb929c0d43c5b41d2aef8395aa1b028ff34ebd7676  golangci-lint-1.30.0-linux-arm64.rpm
+b60feec3da0dfce79aef36c05dada77bf2aa98f07ad64cf4027bd36ec8db4a4e  golangci-lint-1.30.0-freebsd-amd64.tar.gz
+bd9b633796537dea78d0e6003da7b5f78fe17f7903dc967c3e216411549a53f7  golangci-lint-1.30.0-linux-armv6.deb
+bf1947b191dbbca974a59f3897c999964113c3d3d6098b54e719011d7bcf3db0  golangci-lint-1.30.0-freebsd-armv6.tar.gz
+c8e8fc5753e74d2eb489ad428dbce219eb9907799a57c02bcd8b80b4b98c60d4  golangci-lint-1.30.0-linux-amd64.tar.gz
+cd6deee3c903261f6222991526128637656a4a9ae987a0d54bd4d9b8be6a2162  golangci-lint-1.30.0-linux-s390x.deb
+d15ed16baa62d89ccdf3a6189219a1f4e8820721d9a1e2e361fb92c2525f324e  golangci-lint-1.30.0-linux-armv7.tar.gz
+d87ccd0b50ffdcff03f48a02099144b3668bfee295ee08e838262aa4a801df57  golangci-lint-1.30.0-linux-armv7.rpm
+d9e2fd2d2807d121b5936d419a9027555954b48173e52c743064ebf474f30008  golangci-lint-1.30.0-linux-ppc64le.deb
+e0977ea0542e8a42fe8e91ec32911c6385d4f8f1f23c2be7bca5bece079b10eb  golangci-lint-1.30.0-freebsd-386.tar.gz
+edb2cf91cf6478d5d096fa88c7b13f236b078756bf4f9a6de63a8daf51a716b4  golangci-lint-1.30.0-linux-armv6.rpm
 `

--- a/cmd/internal/make.go
+++ b/cmd/internal/make.go
@@ -87,7 +87,7 @@ func profileAllocBench(benchmarkName string) func() {
 }
 
 func generateTestAllocator() {
-	defer b.AddTarget("generate test allocator")()
+	defer b.AddTarget("🏗  generate test allocator")()
 	b.Run(Go, `run`, `./generator/main.go`,
 		`-type`, `StablePointsVector`,
 		`-dir`, `./generator/internal/testdata/etalon/`,
@@ -95,26 +95,26 @@ func generateTestAllocator() {
 }
 
 func testLib() {
-	defer b.AddTarget("test library code")()
+	defer b.AddTarget("🧪 test library code")()
 	defer forceClean()
 	b.Run(Go, `test`, `-parallel`, parallelism, arenaModule+`/...`)
 	generateTestAllocator()
-	defer b.AddTarget("test generated code")()
+	defer b.AddTarget("🎯 test generated code")()
 	b.Run(Go, `test`, `-parallel`, parallelism, generatorModule+`/internal/testdata/testdata_test`)
 }
 
 func testCodeGen() {
-	defer b.AddTarget("test code generator itself")()
+	defer b.AddTarget("🔦 test code generator itself")()
 	defer forceClean()
 	b.Run(Go, `test`, `-parallel`, parallelism, `github.com/storozhukBM/allocator/generator/...`)
 }
 
 func testRace() {
-	defer b.AddTarget("test library code")()
+	defer b.AddTarget("🧪 test library code")()
 	defer forceClean()
 	b.Run(Go, `test`, `-race`, arenaModule+`/...`)
 	generateTestAllocator()
-	defer b.AddTarget("test generated code")()
+	defer b.AddTarget("🔦 test generated code")()
 	b.Run(Go, `test`, `-race`, generatorModule+`/internal/testdata/testdata_test`)
 	defer forceClean()
 	b.Run(Go, `test`, `-race`, generatorModule+`/...`)
@@ -125,7 +125,7 @@ func clean() {
 }
 
 func forceClean() {
-	defer b.AddTarget("clean")()
+	defer b.AddTarget("🧹 clean")()
 	b.Run(`rm`, `-f`, profileName)
 	b.Run(`rm`, `-f`, `allocation_bench_test.test`)
 	b.Run(`rm`, `-f`, coverageName)
@@ -137,13 +137,13 @@ func forceClean() {
 }
 
 func cleanExecutables() {
-	defer b.AddTarget("clean executables")()
+	defer b.AddTarget("🧻 clean executables")()
 	b.Run(`rm`, `-f`, makeExecutable)
 	b.Run(`rm`, `-rf`, binDirName)
 }
 
 func runLinters() {
-	defer b.AddTarget("run linters")()
+	defer b.AddTarget("🕵️  run linters")()
 	ciLinterExec, downloadErr := downloadCILinter()
 	if downloadErr != nil {
 		b.AddError(downloadErr)
@@ -190,11 +190,11 @@ func main() {
 	buildStart := time.Now()
 	buildErr := b.BuildFromOsArgs()
 	if buildErr != nil {
-		_ = beeep.Notify("Failure", "Allocator build failure: "+buildErr.Error(), "")
+		_ = beeep.Notify("Failure ❌", "Allocator build failure: "+buildErr.Error(), "")
 		os.Exit(-1)
 	}
 	if time.Since(buildStart).Seconds() > 5 {
-		_ = beeep.Notify("Success", "Allocator build success", "")
+		_ = beeep.Notify("Success ✅", "Allocator build success", "")
 	}
 }
 

--- a/generator/internal/template.go
+++ b/generator/internal/template.go
@@ -79,13 +79,13 @@ func (s {{$ttName}}Buffer) SubSlice(low int, high int) {{$ttName}}Buffer {
 	var tVar {{$ttName}}
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct{
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-			offset:    currentPtr.offset + uint32(low*int(tSize)),
+			offset:    currentPtr.offset + uintptr(low*int(tSize)),
 			bucketIdx: currentPtr.bucketIdx,
 			arenaMask: currentPtr.arenaMask,
 	}
@@ -109,13 +109,13 @@ func (s {{$ttName}}Buffer) Get(idx int) {{$ttName}}Ptr {
 	var tVar {{$ttName}}
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct{
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-			offset:    currentPtr.offset + uint32(idx*int(tSize)),
+			offset:    currentPtr.offset + uintptr(idx*int(tSize)),
 			bucketIdx: currentPtr.bucketIdx,
 			arenaMask: currentPtr.arenaMask,
 	}

--- a/generator/internal/testdata/expected/circle.alloc.go
+++ b/generator/internal/testdata/expected/circle.alloc.go
@@ -75,13 +75,13 @@ func (s CircleBuffer) SubSlice(low int, high int) CircleBuffer {
 	var tVar Circle
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct {
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-		offset:    currentPtr.offset + uint32(low*int(tSize)),
+		offset:    currentPtr.offset + uintptr(low*int(tSize)),
 		bucketIdx: currentPtr.bucketIdx,
 		arenaMask: currentPtr.arenaMask,
 	}
@@ -105,13 +105,13 @@ func (s CircleBuffer) Get(idx int) CirclePtr {
 	var tVar Circle
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct {
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-		offset:    currentPtr.offset + uint32(idx*int(tSize)),
+		offset:    currentPtr.offset + uintptr(idx*int(tSize)),
 		bucketIdx: currentPtr.bucketIdx,
 		arenaMask: currentPtr.arenaMask,
 	}

--- a/generator/internal/testdata/expected/circlecolor.alloc.go
+++ b/generator/internal/testdata/expected/circlecolor.alloc.go
@@ -75,13 +75,13 @@ func (s CircleColorBuffer) SubSlice(low int, high int) CircleColorBuffer {
 	var tVar CircleColor
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct {
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-		offset:    currentPtr.offset + uint32(low*int(tSize)),
+		offset:    currentPtr.offset + uintptr(low*int(tSize)),
 		bucketIdx: currentPtr.bucketIdx,
 		arenaMask: currentPtr.arenaMask,
 	}
@@ -105,13 +105,13 @@ func (s CircleColorBuffer) Get(idx int) CircleColorPtr {
 	var tVar CircleColor
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct {
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-		offset:    currentPtr.offset + uint32(idx*int(tSize)),
+		offset:    currentPtr.offset + uintptr(idx*int(tSize)),
 		bucketIdx: currentPtr.bucketIdx,
 		arenaMask: currentPtr.arenaMask,
 	}

--- a/generator/internal/testdata/expected/coordinate.alloc.go
+++ b/generator/internal/testdata/expected/coordinate.alloc.go
@@ -75,13 +75,13 @@ func (s coordinateBuffer) SubSlice(low int, high int) coordinateBuffer {
 	var tVar coordinate
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct {
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-		offset:    currentPtr.offset + uint32(low*int(tSize)),
+		offset:    currentPtr.offset + uintptr(low*int(tSize)),
 		bucketIdx: currentPtr.bucketIdx,
 		arenaMask: currentPtr.arenaMask,
 	}
@@ -105,13 +105,13 @@ func (s coordinateBuffer) Get(idx int) coordinatePtr {
 	var tVar coordinate
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct {
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-		offset:    currentPtr.offset + uint32(idx*int(tSize)),
+		offset:    currentPtr.offset + uintptr(idx*int(tSize)),
 		bucketIdx: currentPtr.bucketIdx,
 		arenaMask: currentPtr.arenaMask,
 	}

--- a/generator/internal/testdata/expected/point.alloc.go
+++ b/generator/internal/testdata/expected/point.alloc.go
@@ -75,13 +75,13 @@ func (s PointBuffer) SubSlice(low int, high int) PointBuffer {
 	var tVar Point
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct {
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-		offset:    currentPtr.offset + uint32(low*int(tSize)),
+		offset:    currentPtr.offset + uintptr(low*int(tSize)),
 		bucketIdx: currentPtr.bucketIdx,
 		arenaMask: currentPtr.arenaMask,
 	}
@@ -105,13 +105,13 @@ func (s PointBuffer) Get(idx int) PointPtr {
 	var tVar Point
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct {
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-		offset:    currentPtr.offset + uint32(idx*int(tSize)),
+		offset:    currentPtr.offset + uintptr(idx*int(tSize)),
 		bucketIdx: currentPtr.bucketIdx,
 		arenaMask: currentPtr.arenaMask,
 	}

--- a/generator/internal/testdata/expected/stablepointsvector.alloc.go
+++ b/generator/internal/testdata/expected/stablepointsvector.alloc.go
@@ -75,13 +75,13 @@ func (s StablePointsVectorBuffer) SubSlice(low int, high int) StablePointsVector
 	var tVar StablePointsVector
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct {
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-		offset:    currentPtr.offset + uint32(low*int(tSize)),
+		offset:    currentPtr.offset + uintptr(low*int(tSize)),
 		bucketIdx: currentPtr.bucketIdx,
 		arenaMask: currentPtr.arenaMask,
 	}
@@ -105,13 +105,13 @@ func (s StablePointsVectorBuffer) Get(idx int) StablePointsVectorPtr {
 	var tVar StablePointsVector
 	tSize := unsafe.Sizeof(tVar)
 	type internalPtr struct {
-		offset    uint32
+		offset    uintptr
 		bucketIdx uint8
 		arenaMask uint16
 	}
 	currentPtr := *(*internalPtr)(unsafe.Pointer(&s.data))
 	newPtr := internalPtr{
-		offset:    currentPtr.offset + uint32(idx*int(tSize)),
+		offset:    currentPtr.offset + uintptr(idx*int(tSize)),
 		bucketIdx: currentPtr.bucketIdx,
 		arenaMask: currentPtr.arenaMask,
 	}

--- a/lib/arena/arena_test/arena_client_test.go
+++ b/lib/arena/arena_test/arena_client_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/storozhukBM/allocator/lib/arena"
 )
@@ -678,24 +679,29 @@ func TestWrongOffsetToRef(t *testing.T) {
 		defer func() {
 			p := recover()
 			assert(p != nil, "p can't be nil")
+			result := fmt.Sprintf("%v", p)
 			assert(
-				strings.Contains(fmt.Sprintf("%v", p), "index out of range"),
+				strings.Contains(result, "index out of range"),
 				"index check should fail the execution",
 			)
 			recoveryHappened = true
 		}()
-		bigAlloc := arena.NewRawAllocator(64)
-		smallAlloc := arena.NewRawAllocator(32)
-
-		_, allocErr := bigAlloc.Alloc(33, 1)
+		bigAlloc := arena.NewDynamicAllocatorWithInitialCapacity(64)
+		ptr, allocErr := bigAlloc.Alloc(1, 1)
 		failOnError(t, allocErr)
+		testPtrWrapper := (*testPtr)(unsafe.Pointer(&ptr))
+		testPtrWrapper.offset -= 1
 
-		ptrFromBig, allocErr := bigAlloc.Alloc(1, 1)
-		failOnError(t, allocErr)
-
-		_ = smallAlloc.ToRef(ptrFromBig)
+		_ = bigAlloc.ToRef(ptr)
 		assert(false, "this point should be unreachable due to panic")
 	}()
 
 	assert(recoveryHappened, "recovery should happen")
+}
+
+type testPtr struct {
+	offset    uintptr
+	bucketIdx uint8
+
+	arenaMask uint16
 }

--- a/lib/arena/arena_test/arena_client_test.go
+++ b/lib/arena/arena_test/arena_client_test.go
@@ -690,7 +690,7 @@ func TestWrongOffsetToRef(t *testing.T) {
 		ptr, allocErr := bigAlloc.Alloc(1, 1)
 		failOnError(t, allocErr)
 		testPtrWrapper := (*testPtr)(unsafe.Pointer(&ptr))
-		testPtrWrapper.offset -= 1
+		testPtrWrapper.offset--
 
 		_ = bigAlloc.ToRef(ptr)
 		assert(false, "this point should be unreachable due to panic")
@@ -700,8 +700,7 @@ func TestWrongOffsetToRef(t *testing.T) {
 }
 
 type testPtr struct {
-	offset    uintptr
-	bucketIdx uint8
-
-	arenaMask uint16
+	offset uintptr
+	_      uint8
+	_      uint16
 }

--- a/lib/arena/bytes.go
+++ b/lib/arena/bytes.go
@@ -58,7 +58,7 @@ func (b Bytes) SubSlice(low int, high int) Bytes {
 	}
 	return Bytes{
 		data: Ptr{
-			offset:    b.data.offset + uint32(low),
+			offset:    b.data.offset + uintptr(low),
 			bucketIdx: b.data.bucketIdx,
 			arenaMask: b.data.arenaMask,
 		},
@@ -239,7 +239,7 @@ func (s *BytesView) growIfNecessary(bytesSlice Bytes, requiredSize int) (Bytes, 
 	}
 	// current allocation offset is the same as previous
 	// we can try to just enhance current buffer
-	nextAllocationIsRightAfterTargetSlice := nextPtr.offset == target.data.offset+uint32(target.cap)
+	nextAllocationIsRightAfterTargetSlice := nextPtr.offset == target.data.offset+target.cap
 	if nextAllocationIsRightAfterTargetSlice && s.alloc.Metrics().AvailableBytes >= requiredSize {
 		_, enhancingErr := s.alloc.AllocUnaligned(uintptr(requiredSize))
 		if enhancingErr != nil {

--- a/lib/arena/common.go
+++ b/lib/arena/common.go
@@ -31,7 +31,7 @@ const AllocationInvalidArgumentError = Error("allocation argument is invalid")
 // but we'd suggest to do it right before use to eliminate its visibility scope
 // and potentially prevent it's escaping to the heap.
 type Ptr struct {
-	offset    uint32
+	offset    uintptr
 	bucketIdx uint8
 
 	arenaMask uint16
@@ -88,11 +88,11 @@ func (p Metrics) String() string {
 	)
 }
 
-func isPowerOfTwo(x uint32) bool {
+func isPowerOfTwo(x uintptr) bool {
 	return x != 0 && (x&(x-1)) == 0
 }
 
-func calculatePadding(offset uint32, targetAlignment uint32) uint32 {
+func calculatePadding(offset uintptr, targetAlignment uintptr) uintptr {
 	mask := targetAlignment - 1
 	return (targetAlignment - (offset & mask)) & mask
 }

--- a/lib/arena/generic.go
+++ b/lib/arena/generic.go
@@ -179,12 +179,11 @@ func (a *GenericAllocator) AllocUnaligned(size uintptr) (Ptr, error) {
 func (a *GenericAllocator) Alloc(size, alignment uintptr) (Ptr, error) {
 	a.init()
 	targetSize := int(size)
-	targetAlignment := uint32(alignment)
 
-	if !isPowerOfTwo(targetAlignment) {
+	if !isPowerOfTwo(alignment) {
 		panic(fmt.Errorf("alignment should be power of 2. actual value: %d", alignment))
 	}
-	targetPadding := calculatePadding(a.target.CurrentOffset().p.offset, targetAlignment)
+	targetPadding := calculatePadding(a.target.CurrentOffset().p.offset, alignment)
 
 	if a.allocationLimitInBytes > 0 && a.usedBytes+targetSize+int(targetPadding) > a.allocationLimitInBytes {
 		return Ptr{}, AllocationLimitError

--- a/lib/arena/raw.go
+++ b/lib/arena/raw.go
@@ -2,10 +2,11 @@ package arena
 
 import (
 	"fmt"
+	"reflect"
 	"unsafe"
 )
 
-const minInternalBufferSize uint32 = 64 * 1024
+const minInternalBufferSize uintptr = 64 * 1024
 
 // RawAllocator is the simplest bump pointer allocator
 // that can operate on top of once allocated byte slice.
@@ -20,15 +21,20 @@ const minInternalBufferSize uint32 = 64 * 1024
 // available in this library, and refer to this one only if you really need to,
 // and you understand all its caveats and potentially unsafe behavior.
 type RawAllocator struct {
-	buffer []byte
-	offset uint32
+	startPtr unsafe.Pointer // strong reference to actual byte slice
+	endPtr   uintptr
+	offset   uintptr
 }
 
 // NewRawAllocator creates an instance of arena.RawAllocator
 // and allocates the whole it's underlying buffer from the heap in advance.
 func NewRawAllocator(size uint32) *RawAllocator {
+	bytes := make([]byte, int(size))
+	startPtr := unsafe.Pointer(&bytes[0])
 	return &RawAllocator{
-		buffer: make([]byte, int(size)),
+		startPtr: startPtr,
+		endPtr:   uintptr(unsafe.Pointer(&bytes[size-1])),
+		offset:   uintptr(startPtr),
 	}
 }
 
@@ -37,9 +43,9 @@ func NewRawAllocator(size uint32) *RawAllocator {
 // This method will figure-out size that will be >= size and will enable certain
 // underlying optimizations like vectorized Clear operation.
 func NewRawAllocatorWithOptimalSize(size uint32) *RawAllocator {
-	targetSize := uint32(max(int(size), int(minInternalBufferSize)))
+	targetSize := uintptr(max(int(size), int(minInternalBufferSize)))
 	additionalPadding := calculatePadding(targetSize, minInternalBufferSize)
-	return NewRawAllocator(targetSize + additionalPadding)
+	return NewRawAllocator(uint32(targetSize + additionalPadding))
 }
 
 // AllocUnaligned performs allocation within an underlying buffer, but without automatic alignment.
@@ -64,13 +70,12 @@ func NewRawAllocatorWithOptimalSize(size uint32) *RawAllocator {
 // but we'd suggest to do it right before use to eliminate its visibility scope
 // and potentially prevent it's escaping to the heap.
 func (a *RawAllocator) AllocUnaligned(size uintptr) (Ptr, error) {
-	targetSize := uint32(size)
-	if targetSize > uint32(len(a.buffer))-a.offset {
+	if a.offset+size > a.endPtr {
 		return Ptr{}, AllocationLimitError
 	}
-	allocationOffset := a.offset
-	a.offset += targetSize
-	return Ptr{offset: allocationOffset}, nil
+	result := Ptr{offset: a.offset}
+	a.offset += size
+	return result, nil
 }
 
 // Alloc performs allocation within an underlying buffer.
@@ -93,24 +98,19 @@ func (a *RawAllocator) AllocUnaligned(size uintptr) (Ptr, error) {
 // but we'd suggest to do it right before use to eliminate its visibility scope
 // and potentially prevent it's escaping to the heap.
 func (a *RawAllocator) Alloc(size uintptr, alignment uintptr) (Ptr, error) {
-	targetSize := uint32(size)
-	targetAlignment := uint32(alignment)
-	paddingSize := calculatePadding(a.offset, targetAlignment)
-
-	if targetSize+paddingSize > uint32(len(a.buffer))-a.offset {
+	paddingSize := calculatePadding(a.offset, alignment)
+	if a.offset+size+paddingSize > a.endPtr {
 		return Ptr{}, AllocationLimitError
 	}
 	a.offset += paddingSize
-
-	allocationOffset := a.offset
-	a.offset += targetSize
-	return Ptr{offset: allocationOffset}, nil
+	result := Ptr{offset: a.offset}
+	a.offset += size
+	return result, nil
 }
 
 // ToRef converts arena.Ptr to unsafe.Pointer.
 //
-// This method performs bounds check, so it can panic if you pass an arena.Ptr
-// allocated by different arena with internal offset bigger than the underlying buffer.
+// This method doesn't perform bounds check.
 //
 // Also, this RawAllocator.ToRef has no protection from the converting arena.Ptr
 // that were allocated by other arenas, so you should be extra careful when using it,
@@ -120,8 +120,7 @@ func (a *RawAllocator) Alloc(size uintptr, alignment uintptr) (Ptr, error) {
 // We'd suggest calling this method right before using the result pointer to eliminate its visibility scope
 // and potentially prevent it's escaping to the heap.
 func (a *RawAllocator) ToRef(p Ptr) unsafe.Pointer {
-	targetOffset := int(p.offset)
-	return unsafe.Pointer(&a.buffer[targetOffset])
+	return unsafe.Pointer(p.offset)
 }
 
 // CurrentOffset returns the current allocation offset.
@@ -137,7 +136,12 @@ func (a *RawAllocator) CurrentOffset() Offset {
 // To avoid such situation please refer to other allocator implementations from this library
 // that provide additional safety checks.
 func (a *RawAllocator) Clear() {
-	bytesToClear := a.buffer
+	sliceHdr := reflect.SliceHeader{
+		Data: uintptr(a.startPtr),
+		Len:  int(a.endPtr-uintptr(a.startPtr)) + 1,
+		Cap:  int(a.endPtr-uintptr(a.startPtr)) + 1,
+	}
+	bytesToClear := *(*[]byte)(unsafe.Pointer(&sliceHdr))
 	if len(bytesToClear) > 0 {
 		padding := calculatePadding(a.offset, minInternalBufferSize)
 		idx := min(int(a.offset+padding), len(bytesToClear))
@@ -151,8 +155,8 @@ func (a *RawAllocator) Clear() {
 // that can be used by end-users or other allocators for introspection.
 func (a *RawAllocator) Stats() Stats {
 	return Stats{
-		UsedBytes:                int(a.offset),
-		AllocatedBytes:           len(a.buffer),
+		UsedBytes:                int(a.offset - uintptr(a.startPtr)),
+		AllocatedBytes:           int(a.endPtr-uintptr(a.startPtr)) + 1,
 		CountOfOnHeapAllocations: 0,
 	}
 }
@@ -162,12 +166,20 @@ func (a *RawAllocator) Stats() Stats {
 func (a *RawAllocator) Metrics() Metrics {
 	return Metrics{
 		Stats:          a.Stats(),
-		AvailableBytes: len(a.buffer) - int(a.offset),
-		MaxCapacity:    len(a.buffer),
+		AvailableBytes: int(a.endPtr - a.offset),
+		MaxCapacity:    int(a.endPtr-uintptr(a.startPtr)) + 1,
 	}
 }
 
 // String provides a string snapshot of the current allocation offset.
 func (a *RawAllocator) String() string {
 	return fmt.Sprintf("rowarena{%v}", a.CurrentOffset())
+}
+
+func (a *RawAllocator) availableBytes() int {
+	return int(a.endPtr - a.offset)
+}
+
+func (a *RawAllocator) len() int {
+	return int(a.endPtr-uintptr(a.startPtr)) + 1
 }

--- a/lib/arena/raw.go
+++ b/lib/arena/raw.go
@@ -144,8 +144,9 @@ func (a *RawAllocator) Clear() {
 	}
 	bytesToClear := *(*[]byte)(unsafe.Pointer(&sliceHdr))
 	if len(bytesToClear) > 0 {
-		padding := calculatePadding(a.offset, minInternalBufferSize)
-		idx := min(int(a.offset+padding), len(bytesToClear))
+		sliceOffset := a.idx()
+		padding := calculatePadding(sliceOffset, minInternalBufferSize)
+		idx := min(int(sliceOffset+padding), len(bytesToClear))
 		bytesToClear = bytesToClear[:idx]
 	}
 	clearBytes(bytesToClear)
@@ -179,6 +180,10 @@ func (a *RawAllocator) String() string {
 
 func (a *RawAllocator) availableBytes() int {
 	return int(a.endPtr - a.offset)
+}
+
+func (a *RawAllocator) idx() uintptr {
+	return a.offset - uintptr(a.startPtr)
 }
 
 func (a *RawAllocator) len() int {


### PR DESCRIPTION
Unfortunately, we can't make this allocator be safe with potential movable GC. I decided to try to use unsafe porter arithmetic in raw allocator to fix previously unsolvable potential alignment problems.

```
name                                               old time/op    new time/op    delta
InternalAllocator-4                                  1.67µs ± 7%    1.68µs ± 6%    ~     (p=1.000 n=10+10)
ManagedRawAllocator-4                                 335ns ± 7%     347ns ±11%    ~     (p=0.101 n=10+10)
ManagedDynamicAllocator-4                             894ns ± 7%     941ns ±13%    ~     (p=0.078 n=10+10)
ManagedDynamicAllocatorWithPreAlloc-4                 361ns ± 9%     341ns ± 8%  -5.54%  (p=0.027 n=10+10)
ManagedGenericAllocatorWithPreAllocWithSubClean-4     349ns ± 6%     352ns ± 6%    ~     (p=0.565 n=10+10)
RawAllocator-4                                        478ns ± 1%     478ns ± 2%    ~     (p=0.695 n=10+10)
GenericAllocatorWithSubClean-4                        964ns ± 2%     968ns ± 4%    ~     (p=0.539 n=10+10)
GenericAllocatorWithoutSubClean-4                    1.48µs ± 1%    1.47µs ± 2%    ~     (p=0.535 n=9+10)
GenericAllocatorWithoutSubCleanWithLimit-4           1.49µs ± 4%    1.49µs ± 2%    ~     (p=0.984 n=10+10)
GenericAllocatorWithPreAllocWithoutSubClean-4        1.50µs ± 3%    1.48µs ± 3%    ~     (p=0.139 n=8+10)
GenericAllocatorWithPreAllocWithSubClean-4            513ns ± 5%     507ns ± 5%    ~     (p=0.202 n=9+10)
DynamicAllocator-4                                    958ns ± 2%     956ns ± 4%    ~     (p=0.725 n=10+10)

name                                               old alloc/op   new alloc/op   delta
InternalAllocator-4                                  7.55kB ± 0%    7.55kB ± 0%  -0.01%  (p=0.006 n=9+10)
ManagedRawAllocator-4                                  169B ±33%      159B ±23%    ~     (p=0.508 n=10+9)
ManagedDynamicAllocator-4                            1.36kB ±12%    1.47kB ± 9%  +8.02%  (p=0.026 n=10+9)
ManagedDynamicAllocatorWithPreAlloc-4                  365B ±29%      317B ±26%    ~     (p=0.149 n=10+10)
ManagedGenericAllocatorWithPreAllocWithSubClean-4      358B ±34%      340B ±23%    ~     (p=0.342 n=10+10)
RawAllocator-4                                        0.00B          0.00B         ~     (all equal)
GenericAllocatorWithSubClean-4                        54.0B ± 0%     54.6B ± 3%    ~     (p=0.185 n=6+9)
GenericAllocatorWithoutSubClean-4                    15.1kB ± 0%    15.1kB ± 0%    ~     (p=0.423 n=10+10)
GenericAllocatorWithoutSubCleanWithLimit-4           15.1kB ± 0%    15.1kB ± 0%    ~     (p=0.360 n=10+10)
GenericAllocatorWithPreAllocWithoutSubClean-4        15.0kB ± 0%    15.0kB ± 0%    ~     (all equal)
GenericAllocatorWithPreAllocWithSubClean-4            0.00B          0.00B         ~     (all equal)
DynamicAllocator-4                                    54.1B ± 7%     53.4B ± 3%    ~     (p=0.493 n=10+9)

name                                               old allocs/op  new allocs/op  delta
InternalAllocator-4                                    1.00 ± 0%      1.00 ± 0%    ~     (all equal)
ManagedRawAllocator-4                                  0.00           0.00         ~     (all equal)
ManagedDynamicAllocator-4                              0.00           0.00         ~     (all equal)
ManagedDynamicAllocatorWithPreAlloc-4                  0.00           0.00         ~     (all equal)
ManagedGenericAllocatorWithPreAllocWithSubClean-4      0.00           0.00         ~     (all equal)
RawAllocator-4                                         0.00           0.00         ~     (all equal)
GenericAllocatorWithSubClean-4                         0.00           0.00         ~     (all equal)
GenericAllocatorWithoutSubClean-4                      0.00           0.00         ~     (all equal)
GenericAllocatorWithoutSubCleanWithLimit-4             0.00           0.00         ~     (all equal)
GenericAllocatorWithPreAllocWithoutSubClean-4          0.00           0.00         ~     (all equal)
GenericAllocatorWithPreAllocWithSubClean-4             0.00           0.00         ~     (all equal)
DynamicAllocator-4                                     0.00           0.00         ~     (all equal)
```


