### PR TITLE
Split growIfNecessary method to make required size check inlineable.

### DIFF
--- a/generator/internal/template.go
+++ b/generator/internal/template.go
@@ -397,6 +397,16 @@ func (s *internal{{.TypeNameWithUpperFirstLetter}}BufferView) growIfNecessary(
 		return slice, nil
 	}
 
+	return s.grow(slice, requiredLen)
+}
+
+func (s *internal{{.TypeNameWithUpperFirstLetter}}BufferView) grow(
+		slice {{$ttName}}Buffer,
+		requiredLen int,
+) ({{$ttName}}Buffer, error) {
+	var tVar {{$ttName}}
+	tSize := unsafe.Sizeof(tVar)
+	requiredSizeInBytes := requiredLen * int(tSize)
 	emptyPtr := arena.Ptr{}
 	if s.state.lastAllocatedPtr != emptyPtr && slice.data == s.state.lastAllocatedPtr {
 		nextPtr, probeAllocErr := s.state.alloc.Alloc(0, 1)

--- a/generator/internal/testdata/expected/circle.alloc.go
+++ b/generator/internal/testdata/expected/circle.alloc.go
@@ -388,6 +388,16 @@ func (s *internalCircleBufferView) growIfNecessary(
 		return slice, nil
 	}
 
+	return s.grow(slice, requiredLen)
+}
+
+func (s *internalCircleBufferView) grow(
+	slice CircleBuffer,
+	requiredLen int,
+) (CircleBuffer, error) {
+	var tVar Circle
+	tSize := unsafe.Sizeof(tVar)
+	requiredSizeInBytes := requiredLen * int(tSize)
 	emptyPtr := arena.Ptr{}
 	if s.state.lastAllocatedPtr != emptyPtr && slice.data == s.state.lastAllocatedPtr {
 		nextPtr, probeAllocErr := s.state.alloc.Alloc(0, 1)

--- a/generator/internal/testdata/expected/circlecolor.alloc.go
+++ b/generator/internal/testdata/expected/circlecolor.alloc.go
@@ -388,6 +388,16 @@ func (s *internalCircleColorBufferView) growIfNecessary(
 		return slice, nil
 	}
 
+	return s.grow(slice, requiredLen)
+}
+
+func (s *internalCircleColorBufferView) grow(
+	slice CircleColorBuffer,
+	requiredLen int,
+) (CircleColorBuffer, error) {
+	var tVar CircleColor
+	tSize := unsafe.Sizeof(tVar)
+	requiredSizeInBytes := requiredLen * int(tSize)
 	emptyPtr := arena.Ptr{}
 	if s.state.lastAllocatedPtr != emptyPtr && slice.data == s.state.lastAllocatedPtr {
 		nextPtr, probeAllocErr := s.state.alloc.Alloc(0, 1)

--- a/generator/internal/testdata/expected/coordinate.alloc.go
+++ b/generator/internal/testdata/expected/coordinate.alloc.go
@@ -388,6 +388,16 @@ func (s *internalCoordinateBufferView) growIfNecessary(
 		return slice, nil
 	}
 
+	return s.grow(slice, requiredLen)
+}
+
+func (s *internalCoordinateBufferView) grow(
+	slice coordinateBuffer,
+	requiredLen int,
+) (coordinateBuffer, error) {
+	var tVar coordinate
+	tSize := unsafe.Sizeof(tVar)
+	requiredSizeInBytes := requiredLen * int(tSize)
 	emptyPtr := arena.Ptr{}
 	if s.state.lastAllocatedPtr != emptyPtr && slice.data == s.state.lastAllocatedPtr {
 		nextPtr, probeAllocErr := s.state.alloc.Alloc(0, 1)

--- a/generator/internal/testdata/expected/point.alloc.go
+++ b/generator/internal/testdata/expected/point.alloc.go
@@ -388,6 +388,16 @@ func (s *internalPointBufferView) growIfNecessary(
 		return slice, nil
 	}
 
+	return s.grow(slice, requiredLen)
+}
+
+func (s *internalPointBufferView) grow(
+	slice PointBuffer,
+	requiredLen int,
+) (PointBuffer, error) {
+	var tVar Point
+	tSize := unsafe.Sizeof(tVar)
+	requiredSizeInBytes := requiredLen * int(tSize)
 	emptyPtr := arena.Ptr{}
 	if s.state.lastAllocatedPtr != emptyPtr && slice.data == s.state.lastAllocatedPtr {
 		nextPtr, probeAllocErr := s.state.alloc.Alloc(0, 1)

--- a/generator/internal/testdata/expected/stablepointsvector.alloc.go
+++ b/generator/internal/testdata/expected/stablepointsvector.alloc.go
@@ -388,6 +388,16 @@ func (s *internalStablePointsVectorBufferView) growIfNecessary(
 		return slice, nil
 	}
 
+	return s.grow(slice, requiredLen)
+}
+
+func (s *internalStablePointsVectorBufferView) grow(
+	slice StablePointsVectorBuffer,
+	requiredLen int,
+) (StablePointsVectorBuffer, error) {
+	var tVar StablePointsVector
+	tSize := unsafe.Sizeof(tVar)
+	requiredSizeInBytes := requiredLen * int(tSize)
 	emptyPtr := arena.Ptr{}
 	if s.state.lastAllocatedPtr != emptyPtr && slice.data == s.state.lastAllocatedPtr {
 		nextPtr, probeAllocErr := s.state.alloc.Alloc(0, 1)

--- a/lib/arena/bytes.go
+++ b/lib/arena/bytes.go
@@ -232,6 +232,10 @@ func (s *BytesView) growIfNecessary(bytesSlice Bytes, requiredSize int) (Bytes, 
 		return target, nil
 	}
 
+	return s.grow(target, requiredSize)
+}
+
+func (s *BytesView) grow(target Bytes, requiredSize int) (Bytes, error) {
 	nextPtr, probeAllocErr := s.alloc.AllocUnaligned(0)
 	if probeAllocErr != nil {
 		return Bytes{}, probeAllocErr


### PR DESCRIPTION
On 3.8 GHz 8-Core Intel Core i7
```
name                                                old time/op    new time/op    delta
InternalAllocator-16                                   686ns ± 0%     687ns ± 0%    ~     (p=0.222 n=5+5)
ManagedRawAllocator-16                                 226ns ± 1%     227ns ± 1%    ~     (p=0.246 n=5+5)
ManagedDynamicAllocator-16                             512ns ± 9%     489ns ± 6%    ~     (p=0.056 n=5+5)
ManagedDynamicAllocatorWithPreAlloc-16                 232ns ± 1%     232ns ± 1%    ~     (p=0.730 n=5+5)
ManagedGenericAllocatorWithPreAllocWithSubClean-16     240ns ± 0%     241ns ± 1%    ~     (p=0.421 n=5+5)
RawAllocator-16                                        256ns ± 0%     252ns ± 0%  -1.48%  (p=0.008 n=5+5)
GenericAllocatorWithSubClean-16                        403ns ± 2%     396ns ± 1%    ~     (p=0.119 n=5+5)
GenericAllocatorWithoutSubClean-16                     817ns ± 1%     824ns ± 2%    ~     (p=0.595 n=5+5)
GenericAllocatorWithoutSubCleanWithLimit-16            818ns ± 0%     826ns ± 2%    ~     (p=0.206 n=5+5)
GenericAllocatorWithPreAllocWithoutSubClean-16         817ns ± 1%     817ns ± 2%    ~     (p=0.817 n=5+5)
GenericAllocatorWithPreAllocWithSubClean-16            277ns ± 0%     274ns ± 0%  -1.08%  (p=0.016 n=4+5)
DynamicAllocator-16                                    387ns ± 1%     383ns ± 0%  -0.98%  (p=0.016 n=5+4)

name                                                old alloc/op   new alloc/op   delta
InternalAllocator-16                                  7.55kB ± 0%    7.55kB ± 0%    ~     (all equal)
ManagedRawAllocator-16                                 46.0B ± 0%     48.6B ±21%    ~     (p=0.794 n=4+5)
ManagedDynamicAllocator-16                            1.25kB ±18%    1.12kB ± 7%    ~     (p=0.087 n=5+5)
ManagedDynamicAllocatorWithPreAlloc-16                  114B ±46%      112B ±51%    ~     (p=0.810 n=5+5)
ManagedGenericAllocatorWithPreAllocWithSubClean-16      135B ±30%      132B ±42%    ~     (p=0.952 n=5+5)
RawAllocator-16                                        0.00B          0.00B         ~     (all equal)
GenericAllocatorWithSubClean-16                        23.0B ± 0%     22.0B ± 0%  -4.35%  (p=0.029 n=4+4)
GenericAllocatorWithoutSubClean-16                    15.1kB ± 0%    15.1kB ± 0%    ~     (p=0.389 n=5+5)
GenericAllocatorWithoutSubCleanWithLimit-16           15.1kB ± 0%    15.1kB ± 0%    ~     (p=0.659 n=5+5)
GenericAllocatorWithPreAllocWithoutSubClean-16        15.0kB ± 0%    15.0kB ± 0%    ~     (p=0.897 n=5+5)
GenericAllocatorWithPreAllocWithSubClean-16            0.00B          0.00B         ~     (all equal)
DynamicAllocator-16                                    22.0B ± 0%     22.0B ± 0%    ~     (all equal)

name                                                old allocs/op  new allocs/op  delta
InternalAllocator-16                                    1.00 ± 0%      1.00 ± 0%    ~     (all equal)
ManagedRawAllocator-16                                  0.00           0.00         ~     (all equal)
ManagedDynamicAllocator-16                              0.00           0.00         ~     (all equal)
ManagedDynamicAllocatorWithPreAlloc-16                  0.00           0.00         ~     (all equal)
ManagedGenericAllocatorWithPreAllocWithSubClean-16      0.00           0.00         ~     (all equal)
RawAllocator-16                                         0.00           0.00         ~     (all equal)
GenericAllocatorWithSubClean-16                         0.00           0.00         ~     (all equal)
GenericAllocatorWithoutSubClean-16                      0.00           0.00         ~     (all equal)
GenericAllocatorWithoutSubCleanWithLimit-16             0.00           0.00         ~     (all equal)
GenericAllocatorWithPreAllocWithoutSubClean-16          0.00           0.00         ~     (all equal)
GenericAllocatorWithPreAllocWithSubClean-16             0.00           0.00         ~     (all equal)
DynamicAllocator-16                                     0.00           0.00         ~     (all equal)
```